### PR TITLE
Fixed file path for serving classify.html over SimpleHTTPServer

### DIFF
--- a/classify/main.py
+++ b/classify/main.py
@@ -38,7 +38,8 @@ def serve(port):
     Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
     httpd = SocketServer.TCPServer(('', port), Handler)
     print('Serving on port: {0}'.format(port))
-    webbrowser.open_new_tab('http://localhost:{0}/classify.html'.format(port))
+    webbrowser.open_new_tab('http://localhost:{0}/'
+                            'output/classify.html'.format(port))
     httpd.serve_forever()
 
 


### PR DESCRIPTION
When using `classify KLASS --html --serve --port <port>` classify writes the documentation for `KLASS` to `/current/directory/output/classify.html`. However, it attempts to serve the documentation from `/current/directory/classify.html`. I have made a simple change so it serves the correct file.

For future reference, perhaps `classify` should write the documentation to a folder with a less generic name than output.
