### PR TITLE
Make sure methods are callable

### DIFF
--- a/src/classify/filters.py
+++ b/src/classify/filters.py
@@ -42,6 +42,7 @@ def is_method(member: Member) -> bool:
             "class method",
             "static method",
         ]
+        and callable(member.obj)
         and not isinstance(
             member.obj,
             (


### PR DESCRIPTION
Django's DeferredAttribute gets reported as method by pydoc.classify_class_attrs, but is not callable, so Method.from_func crashes.