### PR TITLE
Make sure methods are callable

### DIFF
--- a/src/classify/filters.py
+++ b/src/classify/filters.py
@@ -42,6 +42,7 @@ def is_method(member: Member) -> bool:
             "class method",
             "static method",
         ]
+        and callable(member.obj)
         and not isinstance(
             member.obj,
             (


### PR DESCRIPTION
From #37:

> Django's DeferredAttribute gets reported as method by pydoc.classify_class_attrs, but is not callable, so Method.from_func crashes.

---

Now that 61d61191 is in, the tests for this should correctly fail in CI.